### PR TITLE
feat: add main screen and config trivia screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,16 @@
 import 'package:flutter/material.dart';
-//import 'package:trivia/presentation/screens/main_screen.dart';
 import 'package:trivia/presentation/screens/trivia_config_screen.dart';
 
 void main() {
   runApp(myApp());
-
 }
 
 class myApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: Trivia_config_screen(),
+      home: TriviaConfigScreen(),
     );
-  }
-  
+  } 
 }
-

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,21 @@
-
+import 'package:flutter/material.dart';
+//import 'package:trivia/presentation/screens/main_screen.dart';
+import 'package:trivia/presentation/screens/trivia_config_screen.dart';
 
 void main() {
+  runApp(myApp());
 
 }
+
+class myApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Trivia_config_screen(),
+    );
+  }
+  
+}
+

--- a/lib/presentation/screens/main_screen.dart
+++ b/lib/presentation/screens/main_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class Main_Screen extends StatelessWidget{
+  @override
+  Widget build(BuildContext context) {
+    
+    return Scaffold(
+      appBar: AppBar(title: Text("Trivia"),),
+      body: Center(child: ElevatedButton(onPressed: (){}, child: Text("New Trivia")))
+    );
+  }
+
+}

--- a/lib/presentation/screens/trivia_config_screen.dart
+++ b/lib/presentation/screens/trivia_config_screen.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:trivia/presentation/widgets/dropdown_menu.dart';
+
+
+class Trivia_config_screen extends StatefulWidget{
+
+  Trivia_config_screen({super.key});
+
+  @override
+  State<Trivia_config_screen> createState() => _Trivia_config_screenState();
+}
+
+class _Trivia_config_screenState extends State<Trivia_config_screen> {
+  late List<String> categories = [""];
+  late List<String> difficult;
+  late List<String> types;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("Trivia"),),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+            const Text("Number of questions:"),
+            Container(width: 50,
+              child: TextField()),
+      
+            Text("Difficult"),  
+            CustomDropdownMenu(list: categories),
+      
+            Text("Category:"),
+            CustomDropdownMenu(list: categories),
+      
+            const Text("type of Trivia:"),
+            CustomDropdownMenu(list: categories),
+      
+            ElevatedButton(onPressed: (){}, child: Text("Start Trivia"))
+          ],),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/trivia_config_screen.dart
+++ b/lib/presentation/screens/trivia_config_screen.dart
@@ -1,16 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:trivia/presentation/widgets/dropdown_menu.dart';
 
-
-class Trivia_config_screen extends StatefulWidget{
-
-  Trivia_config_screen({super.key});
+class TriviaConfigScreen extends StatefulWidget {
+  TriviaConfigScreen({super.key});
 
   @override
-  State<Trivia_config_screen> createState() => _Trivia_config_screenState();
+  State<TriviaConfigScreen> createState() => _TriviaConfigScreenState();
 }
 
-class _Trivia_config_screenState extends State<Trivia_config_screen> {
+class _TriviaConfigScreenState extends State<TriviaConfigScreen> {
   late List<String> categories = [""];
   late List<String> difficult;
   late List<String> types;
@@ -18,28 +16,26 @@ class _Trivia_config_screenState extends State<Trivia_config_screen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("Trivia"),),
+      appBar: AppBar(
+        title: const Text("Trivia"),
+      ),
       body: Padding(
         padding: const EdgeInsets.all(20),
         child: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-            const Text("Number of questions:"),
-            Container(width: 50,
-              child: TextField()),
-      
-            Text("Difficult"),  
-            CustomDropdownMenu(list: categories),
-      
-            Text("Category:"),
-            CustomDropdownMenu(list: categories),
-      
-            const Text("type of Trivia:"),
-            CustomDropdownMenu(list: categories),
-      
-            ElevatedButton(onPressed: (){}, child: Text("Start Trivia"))
-          ],),
+              const Text("Number of questions:"),
+              const SizedBox(width: 50, child: TextField()),
+              const Text("Difficult"),
+              CustomDropdownMenu(list: categories),
+              const Text("Category:"),
+              CustomDropdownMenu(list: categories),
+              const Text("type of Trivia:"),
+              CustomDropdownMenu(list: categories),
+              ElevatedButton(onPressed: () {}, child: const Text("Start Trivia"))
+            ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/widgets/dropdown_menu.dart
+++ b/lib/presentation/widgets/dropdown_menu.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+// ignore: must_be_immutable
+class CustomDropdownMenu extends StatefulWidget{
+
+  CustomDropdownMenu({required this.list}){
+    itemSelected = list[0];
+  }
+
+  final List<String> list;
+  late String itemSelected;
+
+  @override
+  State<CustomDropdownMenu> createState() => _CustomDropdownMenuState();
+}
+
+class _CustomDropdownMenuState extends State<CustomDropdownMenu> {
+  @override
+  Widget build(BuildContext context) {
+    
+
+    return DropdownButton(
+            value: widget.itemSelected,
+            items: widget.list.map((String category) {
+              return DropdownMenuItem<String>(
+                value: category,
+                child: Text(category),
+              );
+            }).toList(), 
+            onChanged: (String? value) {
+              setState((){
+                widget.itemSelected = value ?? "b";
+              });
+              
+            });
+  }
+}


### PR DESCRIPTION
## Task
create the main screen and a second screen to configure the trivia.

## New Features:
**main_screen**: The initial screen has been created, featuring a button that initiates the configuration of a new trivia.
**config_trivia_screen**: It includes a form with drop-down menus that fetch information from the API.

